### PR TITLE
correção em validação de cpf vazio ou não numerico

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "type": "node",
             "request": "launch",
             "name": "Launch Program",
-            "program": "${workspaceFolder}\\xx.js"
+            "program": "${workspaceFolder}\\dist\\cpf.js"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}\\xx.js"
+        }
+    ]
+}

--- a/lib/utils/is-repeated.js
+++ b/lib/utils/is-repeated.js
@@ -2,7 +2,10 @@
 
 const split = str => str.split("");
 
-const reduce = val => val.reduce((a, b) => a === b ? a : "");
+const reduce = val =>
+       val.length === 0
+       ? ""
+       : val.reduce((a, b) => a === b ? a : "");
 
 const isRepeated = str => Boolean(reduce(split(str)));
 

--- a/tests/lib/is-valid.spec.js
+++ b/tests/lib/is-valid.spec.js
@@ -8,9 +8,12 @@ describe("isValid:", () => {
     expect(isValid("111.444.777")).toBeFalsy();
     expect(isValid("111.444.777-42")).toBeFalsy();
     expect(isValid("111.111.111-11")).toBeFalsy();
+    expect(isValid("")).toBeFalsy();
+    expect(isValid("string")).toBeFalsy();
   });
   it("deve verificar se um número de cpf é tem um tamanho válido", () => {
     expect(isValid("111.444.777-35", true)).toBeTruthy();
     expect(isValid("111.444.777", true)).toBeFalsy();
   });
+
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,8 +8,8 @@ const banner = `${name} v${version} | (c) ${year} by ${author}`;
 
 module.exports = {
   entry: {
-    "piii": "./index.js",
-    "piii.min": "./index.js"
+    "cpf": "./index.js",
+    "cpf.min": "./index.js"
   },
   output: {
     path: path.resolve(__dirname, "dist"),


### PR DESCRIPTION
Estourava exception ao tentar validar uma string vazia ou uma sem números.