### PR TITLE
Refatoração da função format

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -1,3 +1,18 @@
+const mask = {
+  cpf(val) {
+    return val
+      .replace(/(\d{11})\d/, '$1')
+      .replace(/(\d{3})(\d)/, '$1.$2')
+      .replace(/(\d{3})(\d)/, '$1.$2')
+      .replace(/(\d{3})(\d)/, '$1-$2');
+  },
+};
+
+
+const onlyDigits = val => {
+  return val.replace(/\D/g, '');
+};
+
 /**
  * Format a CPF number.
  *
@@ -5,18 +20,6 @@
  * @returns {string} Formatted CPF number.
  */
 module.exports = (cpfNumber) => {
-  if (typeof cpfNumber !== 'string') {
-    throw new Error('Invalid CPF number')
-  }
-
-  const unformattedCpf = cpfNumber.replace(/\D/g, '')
-
-  if (unformattedCpf.length !== 11) {
-    throw new Error('Invalid CPF number')
-  }
-
-  const regex = /^(\d{3})(\d{3})(\d{3})(\d{2})$/
-  const mask = '$1.$2.$3-$4'
-
-  return unformattedCpf.replace(regex, mask)
+  const digits = onlyDigits(cpfNumber);
+  return mask.cpf(digits);
 }


### PR DESCRIPTION
Com essa refatoração a função `format` irá permitir apenas números e irá formatar com '.' e '-' de acordo com o padrão de cpf.